### PR TITLE
Ensure the position contraint in strain calculation works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Distribution / packaging
+*.egg-info/
+posecheck/__pycache__/*.pyc
+*/*/__pycache__/

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ datamol
 #openbabel
 
 # Data
-pandas
+pandas==2.0.0
 seaborn
 matplotlib
 numpy


### PR DESCRIPTION
1. Change the force constant to 1.0e5 to ensure that the position constraint added in strain energy calculation is correctly implemented.
2. Add another relaxation on the given pose to ensure that strain energy is always positive.
3. Pin the pandas version to avoid environment issues.